### PR TITLE
Fix bug and create conventional commit PR

### DIFF
--- a/portfolio/portfolio/api.py
+++ b/portfolio/portfolio/api.py
@@ -27,7 +27,7 @@ def submit_contact(name=None, email=None, subject=None, message=None):
         return {'status': 'error', 'message': f"Missing values: {', '.join(missing)}"}
 
     # Validate email format (simple regex)
-    if not re.match(r"^[^@]+@[^@]+\\.[^@]+$", email or ""):
+    if not re.match(r"^[^@]+@[^@]+\.[^@]+$", email or ""):
         frappe.local.response['http_status_code'] = 400
         return {'status': 'error', 'message': 'Invalid email address.'}
 


### PR DESCRIPTION
Correct email regex in `submit_contact` to accept valid email addresses.

The previous regex `r"^[^@]+@[^@]+\\.[^@]+$"` incorrectly used `\\.` in a raw string, which matched a literal backslash followed by any character. This caused valid emails (e.g., `user@example.com`) to be rejected. The fix changes `\\.` to `\.` to correctly match a literal dot in the domain part.

---
<a href="https://cursor.com/background-agent?bcId=bc-ecec1b00-801f-4fd5-a541-2d7d4f53982e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ecec1b00-801f-4fd5-a541-2d7d4f53982e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

